### PR TITLE
DESeq2 and DEXseq now run

### DIFF
--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -68,7 +68,6 @@ def check_samplesheet(FileIn,FileOut):
 
             ## CHECK FASTQ ENTRIES
             if sample_path:
-                dir_path = '/'.join(sample_path.split('/')[:-1])
                 if sample_path[-9:] != '.fastq.gz' and sample_path[-6:] != '.fq.gz' and sample_path[-4:] != ".bam":
                     print_error("FastQ file does not have extension '.fastq.gz' or '.fq.gz' or '.bam'!",line)
                     sys.exit(1)
@@ -106,14 +105,14 @@ def check_samplesheet(FileIn,FileOut):
                     is_transcripts = '1'
                     genome = transcriptome
 
-            outLines.append([sample,sample_path,barcode,genome,gtf,is_transcripts,dir_path,condition])
+            outLines.append([sample,sample_path,barcode,genome,gtf,is_transcripts,condition])
         else:
             fin.close()
             break
 
     ## WRITE TO FILE
     fout = open(FileOut,'w')
-    fout.write(','.join(['sample', 'sample_path', 'barcode', 'genome', 'gtf', 'is_transcripts','dir_path','condition']) + '\n')
+    fout.write(','.join(['sample', 'sample_path', 'barcode', 'genome', 'gtf', 'is_transcripts','condition']) + '\n')
     for line in outLines:
         fout.write(','.join(line) + '\n')
     fout.close()

--- a/bin/runBambu.R
+++ b/bin/runBambu.R
@@ -4,20 +4,13 @@
 library(bambu)
 args = commandArgs(trailingOnly=TRUE)
 
-readlist <- strsplit(grep('--input*', args, value = TRUE), split = '=')[[1]][[2]]
-readlist <- trimws(unlist(strsplit(gsub("\\[|\\]", "",readlist),",")))
 output_tag <- strsplit(grep('--tag*', args, value = TRUE), split = '=')[[1]][[2]]
 ncore <- strsplit(grep('--ncore*', args, value = TRUE), split = '=')[[1]][[2]]
-
-if (length(args) < 5) {
-  stop("Please input the fullpath for the present directory and the sample sheet.", call.=FALSE)
-} else {
-  genomeseq <- strsplit(grep('--fasta*', args, value = TRUE), split = '=')[[1]][[2]]
-  genomeSequence <- Rsamtools::FaFile(genomeseq)
-  Rsamtools::indexFa(genomeseq)
-}
+genomeseq <- strsplit(grep('--fasta*', args, value = TRUE), split = '=')[[1]][[2]]
+genomeSequence <- Rsamtools::FaFile(genomeseq)
+Rsamtools::indexFa(genomeseq)
 annot_gtf <- strsplit(grep('--annotation*', args, value = TRUE), split = '=')[[1]][[2]]
-
+readlist <- args[5:length(args)]
 
 grlist <- prepareAnnotations(annot_gtf)
 se <- bambu(reads = readlist, annotations = grlist,genomeSequence = genomeSequence, ncore = ncore, verbose = TRUE)

--- a/bin/runDESeq2.R
+++ b/bin/runDESeq2.R
@@ -1,12 +1,6 @@
 #!/usr/bin/env Rscript
 
-if (!requireNamespace("BiocManager", quietly = TRUE)){
-    install.packages("BiocManager", repos='http://cran.us.r-project.org')
- }
-if (!require("DESeq2")){
-    BiocManager::install("DESeq2",update = FALSE, ask= FALSE)
-    library(DESeq2)
-}
+library(DESeq2)
 
 args = commandArgs(trailingOnly=TRUE)
 if (length(args) < 3) {
@@ -35,12 +29,12 @@ if (transcriptquant == "bambu"){
 
 #sampInfo <- read.csv("~/Downloads/nanorna-bam-master/two_conditions.csv",row.names = 1)
 sampInfo<-read.csv(args[3],row.names=1)
-#all(rownames(sampInfo) %in% colnames(countTab))
-#all(rownames(sampInfo) == colnames(countTab))
+if (!all(rownames(sampInfo) == colnames(countTab))){
+  sampInfo <- sampInfo[match(colnames(countTab), rownames(sampInfo)),]
+}
 dds <- DESeqDataSetFromMatrix(countData = countTab,colData = sampInfo,design = ~ condition)
 dds <- DESeq(dds)
 res <- results(dds)
 #register(MulticoreParam(6))
 resOrdered <- res[order(res$pvalue),]
 write.csv(as.data.frame(resOrdered), file=args[4])
-

--- a/bin/runDESeq2.R
+++ b/bin/runDESeq2.R
@@ -23,8 +23,8 @@ if (transcriptquant == "stringtie"){
   rownames(countTab)<-count.matrix[,1]
 }
 if (transcriptquant == "bambu"){
- 
-  countTab <- data.frame(read.table(path,sep="\t",header=TRUE))
+   countTab <- data.frame(read.table(path,sep="\t",header=TRUE))
+   colnames(countTab) <- unlist(lapply(strsplit(colnames(countTab),"\\."),"[[",1))
 }
 
 #sampInfo <- read.csv("~/Downloads/nanorna-bam-master/two_conditions.csv",row.names = 1)

--- a/bin/runDEXseq.R
+++ b/bin/runDEXseq.R
@@ -1,20 +1,8 @@
 #!/usr/bin/env Rscript
 
-if (!requireNamespace("BiocManager", quietly = TRUE)){
-    install.packages("BiocManager", repos='http://cran.us.r-project.org')
- }
-if (!require("DRIMSeq")){
-    BiocManager::install("DRIMSeq",update = FALSE, ask= FALSE)
-    library(DRIMSeq)
-}
-if (!require("DEXSeq")){
-    BiocManager::install("DEXSeq",update = FALSE, ask= FALSE)
-    library(DEXSeq)
-}
-if (!require("stageR")){
-    BiocManager::install("stageR",update = FALSE, ask= FALSE)
-    library(stageR)
-}
+library(DRIMSeq)
+library(DEXSeq)
+library(stageR)
 
 
 args = commandArgs(trailingOnly=TRUE)
@@ -127,4 +115,3 @@ suppressWarnings({
                                  onlySignificantGenes=TRUE)
 })
 write.csv(dxr_pval, file="DEXseq_out.txt")
-

--- a/bin/runDEXseq.R
+++ b/bin/runDEXseq.R
@@ -20,9 +20,9 @@ if (transcriptquant == "stringtie"){
   colnames(count.matrix)[2:length(colnames(count.matrix))] <- unlist(lapply(strsplit(colnames(count.matrix)[2:length(colnames(count.matrix))],"\\."),"[[",1))
 
 }
-
 if (transcriptquant == "bambu"){
   count.matrix <- data.frame(read.table(path,sep="\t",header=T))
+  colnames(count.matrix) <- unlist(lapply(strsplit(colnames(count.matrix),"\\."),"[[",1))
 }
 colnames(count.matrix)[1] <- "feature_id"
 colnames(count.matrix)[2] <- "gene_id"

--- a/main.nf
+++ b/main.nf
@@ -920,12 +920,12 @@ if (!params.skip_transcriptquant) {
 
 
             output:
-            file "*gene.txt" into ch_deseq2_in
-            file "*transcript.txt" into ch_dexseq_in
+            file "counts_gene.txt" into ch_deseq2_in
+            file "counts_transcript.txt" into ch_dexseq_in
 
             script:
             """
-            Rscript --vanilla $Bambuscript --input=$bams --tag=Bambu/ --ncore=$task.cpus --annotation=$annot --fasta=$genomeseq 
+            Rscript --vanilla $Bambuscript --input=$bams --tag=. --ncore=$task.cpus --annotation=$annot --fasta=$genomeseq --gene_output=count_gene.txt --transcript_output=count_transcript.txt
             """
         }
     } else {

--- a/main.nf
+++ b/main.nf
@@ -919,7 +919,7 @@ if (!params.skip_transcriptquant) {
 
             script:
             """
-            Rscript --vanilla $Bambuscript --input=$bams --tag=. --ncore=$task.cpus --annotation=$annot --fasta=$genomeseq --gene_output=count_gene.txt --transcript_output=count_transcript.txt
+            Rscript --vanilla $Bambuscript --tag=. --ncore=$task.cpus --annotation=$annot --fasta=$genomeseq $bams
             """
         }
     } else {


### PR DESCRIPTION
Hi @cying111, DESeq2 and DEXseq now run well with either the bam or fastq input options.
Stringtie bam:
![stringtie_bam](https://user-images.githubusercontent.com/41866052/89258624-7cc24900-d5f6-11ea-928e-59c85bc83028.png)
Stringtie fastq:
![stringtie_fastq](https://user-images.githubusercontent.com/41866052/89258617-77fd9500-d5f6-11ea-9d9c-4ec4f0753bbe.png)
Bambu bam:
![bambu_bam](https://user-images.githubusercontent.com/41866052/89258610-7338e100-d5f6-11ea-9425-fbe8aa27fd6f.png)
Bambu fastq:
![bambu_fastq](https://user-images.githubusercontent.com/41866052/89258586-6caa6980-d5f6-11ea-887f-4fff698ecd83.png)