### PR TITLE
add xpore and m6anet

### DIFF
--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -34,7 +34,6 @@ def print_error(error, context='Line', context_str=''):
 def check_samplesheet(file_in, file_out):
     """
     This function checks that the samplesheet follows the following structure:
-
     group,replicate,barcode,input_file,genome,transcriptome
     MCF7,1,,MCF7_directcDNA_replicate1.fastq.gz,genome.fa,
     MCF7,2,,MCF7_directcDNA_replicate3.fastq.gz,genome.fa,genome.gtf
@@ -57,7 +56,7 @@ def check_samplesheet(file_in, file_out):
         ## Check sample entries
         for line in fin:
             lspl = [x.strip() for x in line.strip().split(",")]
-
+            nanopolish_fast5 = ''
             ## Check valid number of columns per row
             if len(lspl) < len(HEADER):
                 print_error("Invalid number of columns (minimum = {})!".format(len(HEADER)), 'Line', line)
@@ -93,14 +92,34 @@ def check_samplesheet(file_in, file_out):
             if input_file:
                 if input_file.find(" ") != -1:
                     print_error("Input file contains spaces!", 'Line', line)
-                if not input_file.endswith(".fastq.gz") and not input_file.endswith(".fq.gz") and not input_file.endswith(".bam"):
-                    print_error("Input file does not have extension '.fastq.gz', '.fq.gz' or '.bam'!", 'Line', line)
                 if input_file.endswith(".fastq.gz"):
                     input_extensions.append("*.fastq.gz")
                 elif input_file.endswith(".fq.gz"):
                     input_extensions.append("*.fq.gz")
                 elif input_file.endswith(".bam"):
                     input_extensions.append("*.bam")
+                else:
+                    list_dir         = os.listdir(input_file)
+                    nanopolish_fast5 = input_file
+                    if not (all(fname.endswith('.fast5') for fname in list_dir)):
+                        if "fast5" in list_dir and "fastq" in list_dir:
+                            nanopolish_fast5 = input_file+'/fast5'
+                            ## CHECK FAST5 DIRECTORY
+                            if not (all(fname.endswith('.fast5') for fname in os.listdir(nanopolish_fast5))):
+                                print_error('fast5 directory contains non-fast5 files.')
+                            ## CHECK PROVIDED BASECALLED FASTQ
+                            fastq_path       = input_file+'/fastq'
+                            basecalled_fastq = [fn for fn in os.listdir(fastq_path) if fn.endswith(".fastq.gz") or fn.endswith(".fq.gz") ]
+                            print(basecalled_fastq)
+                            if len(basecalled_fastq) != 1:
+                                print_error('Please input one basecalled fastq per sample.')
+                            else:
+                                input_file   = fastq_path+'/'+basecalled_fastq[0]
+                                if not basecalled_fastq[0].endswith(".fastq.gz"):
+                                    if not basecalled_fastq[0].endswith(".fq.gz"):
+                                        print_error('basecalled fastq input does not end with ".fastq.gz" or ".fq.gz"')
+                        else:
+                            print_error('path does not end with ".fastq.gz", ".fq.gz", or ".bam" and is not an existing directory with correct fast5 and/or fastq inputs.')
 
             ## Check genome entries
             if genome:
@@ -127,7 +146,7 @@ def check_samplesheet(file_in, file_out):
                     genome = transcriptome
 
             ## Create sample mapping dictionary = {group: {replicate : [ barcode, input_file, genome, gtf, is_transcripts ]}}
-            sample_info = [barcode, input_file, genome, gtf, is_transcripts]
+            sample_info = [barcode, input_file, genome, gtf, is_transcripts, nanopolish_fast5]
             if group not in sample_info_dict:
                 sample_info_dict[group] = {}
             if replicate not in sample_info_dict[group]:
@@ -145,7 +164,7 @@ def check_samplesheet(file_in, file_out):
         make_dir(out_dir)
         with open(file_out, "w") as fout:
 
-            fout.write(",".join(['sample', 'barcode', 'input_file', 'genome', 'gtf', 'is_transcripts']) + "\n")
+            fout.write(",".join(['sample', 'barcode', 'input_file', 'genome', 'gtf', 'is_transcripts', 'nanopolish_fast5']) + "\n")
             for sample in sorted(sample_info_dict.keys()):
 
                 ## Check that replicate ids are in format 1..<NUM_REPS>

--- a/bin/create_yml.py
+++ b/bin/create_yml.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import sys
+outfile_name=sys.argv[1]
+samples=sys.argv[2:]
+outfile=open(outfile_name,"w")
+outfile.write(
+ 'notes: Pairwise comparison without replicates with default parameter setting.'+ '\n'+
+ '\n'+
+ 'data:'+'\n'
+)
+
+dict={}
+for sample in samples:
+ sample=sample.strip("[").strip("]").split(",")
+ path_to_sample,condition=sample[0],sample[1]
+ if condition not in dict:
+  dict[condition]=[path_to_sample]
+ else:
+  dict[condition].append(path_to_sample)
+
+for condition in dict:
+ outfile.write('    '+condition+':'+'\n')
+ r=0
+ for sample in dict[condition]:
+  r+=1
+  outfile.write('        rep'+str(r)+': '+sample+'/xpore'+'\n')
+
+outfile.write('\n'+'out: ./diffmod_outputs'+'\n'+'\n')
+
+outfile.write(
+ 'method:'+'\n'+
+ '    prefiltering:'+'\n'+
+ '        method: t-test'+'\n'+
+ '        threshold: 0.1'+'\n'+'\n'
+)
+
+outfile.close()

--- a/conf/base.config
+++ b/conf/base.config
@@ -32,8 +32,8 @@ process {
     time   = { check_max( 6.h * task.attempt, 'time' ) }
   }
   withLabel:process_medium {
-    cpus   = { check_max( 6 * task.attempt, 'cpus' ) }
-    memory = { check_max( 42.GB * task.attempt, 'memory' ) }
+    cpus   = { check_max( 6 , 'cpus' ) }
+    memory = { check_max( 30.GB, 'memory' ) }
     time   = { check_max( 8.h * task.attempt, 'time' ) }
   }
   withLabel:process_high {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -104,6 +104,18 @@ params {
         'dexseq' {
             publish_dir   = "${params.quantification_method}/dexseq"
         }
+        'nanopolish' {
+            publish_dir   = "nanopolish"
+        }
+        'xpore_m6anet_dataprep' {
+            publish_dir   = "rna_modification/dataprep"
+        }
+        'xpore_diffmod' {
+            publish_dir   = "rna_modification"
+        }
+        'm6anet_inference' {
+            publish_dir   = "rna_modification/m6anet_inference"
+        }
         'multiqc' {
             publish_dir   = "multiqc/${params.aligner}"
         }

--- a/conf/test.config
+++ b/conf/test.config
@@ -17,13 +17,14 @@ params {
   max_time            = 12.h
 
   // Input data to perform both basecalling and demultiplexing
-  input               = 'https://raw.githubusercontent.com/nf-core/test-datasets/nanoseq/samplesheet_bc_dx.csv'
-  protocol            = 'cDNA'
-  flowcell            = 'FLO-MIN106'
-  kit                 = 'SQK-DCS109'
-  barcode_kit         = 'EXP-NBD103'
-  run_nanolyse        = true
-  skip_quantification = true
+  input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/nanoseq/samplesheet_bc_dx.csv'
+  protocol                   = 'cDNA'
+  flowcell                   = 'FLO-MIN106'
+  kit                        = 'SQK-DCS109'
+  barcode_kit                = 'EXP-NBD103'
+  run_nanolyse               = true
+  skip_quantification        = true
+  skip_modification_analysis = true
 
   // This variable is just for reference and isnt actually required for the tests
   // Files are downloaded and staged using the "GetTestData" process

--- a/conf/test_bc_nodx.config
+++ b/conf/test_bc_nodx.config
@@ -17,13 +17,13 @@ params {
   max_time            = 12.h
 
   // Input data to perform basecalling and to skip demultipexing
-  input               = 'https://raw.githubusercontent.com/nf-core/test-datasets/nanoseq/samplesheet_bc_nodx.csv'
-  protocol            = 'cDNA'
-  flowcell            = 'FLO-MIN106'
-  kit                 = 'SQK-DCS108'
-  skip_demultiplexing = true
-  skip_quantification = true
-
+  input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/nanoseq/samplesheet_bc_nodx.csv'
+  protocol                   = 'cDNA'
+  flowcell                   = 'FLO-MIN106'
+  kit                        = 'SQK-DCS108'
+  skip_demultiplexing        = true
+  skip_quantification        = true
+  skip_modification_analysis = true
   // This variable is just for reference and isnt actually required for the tests
   // Files are downloaded and staged using the "GetTestData" process
   input_path          = 'https://raw.githubusercontent.com/nf-core/test-datasets/nanoseq/fast5/nonbarcoded/'

--- a/conf/test_nobc_dx.config
+++ b/conf/test_nobc_dx.config
@@ -17,10 +17,11 @@ params {
   max_time            = 12.h
 
   // Input data to skip basecalling and to only perform demultipexing
-  input               = 'https://raw.githubusercontent.com/nf-core/test-datasets/nanoseq/samplesheet_nobc_dx.csv'
-  protocol            = 'DNA'
-  barcode_kit         = 'NBD103/NBD104'
-  input_path          = 'https://raw.githubusercontent.com/nf-core/test-datasets/nanoseq/fastq/nondemultiplexed/sample_nobc_dx.fastq.gz'
-  skip_basecalling    = true
-  skip_quantification = true
+  input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/nanoseq/samplesheet_nobc_dx.csv'
+  protocol                   = 'DNA'
+  barcode_kit                = 'NBD103/NBD104'
+  input_path                 = 'https://raw.githubusercontent.com/nf-core/test-datasets/nanoseq/fastq/nondemultiplexed/sample_nobc_dx.fastq.gz'
+  skip_basecalling           = true
+  skip_quantification        = true
+  skip_modification_analysis = true
 }

--- a/conf/test_nobc_nodx.config
+++ b/conf/test_nobc_nodx.config
@@ -17,8 +17,9 @@ params {
   max_time            = 12.h
 
   // Input data to skip both basecalling and demultiplexing
-  input               = 'https://raw.githubusercontent.com/nf-core/test-datasets/nanoseq/samplesheet_nobc_nodx.csv'
-  protocol            = 'directRNA'
-  skip_basecalling    = true
-  skip_demultiplexing = true
+  input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/nanoseq/samplesheet_nobc_nodx.csv'
+  protocol                   = 'directRNA'
+  skip_basecalling           = true
+  skip_demultiplexing        = true
+  skip_modification_analysis = true
 }

--- a/conf/test_nobc_nodx_noaln.config
+++ b/conf/test_nobc_nodx_noaln.config
@@ -17,9 +17,10 @@ params {
   max_time            = 12.h
 
   // Input data to skip both basecalling and demultiplexing
-  input                 = 'https://raw.githubusercontent.com/nf-core/test-datasets/nanoseq/samplesheet_nobc_nodx_noaln.csv'
-  protocol              = 'directRNA'
-  skip_basecalling      = true
-  skip_demultiplexing   = true
-  skip_alignment        = true
+  input                      = 'https://raw.githubusercontent.com/nf-core/test-datasets/nanoseq/samplesheet_nobc_nodx_noaln.csv'
+  protocol                   = 'directRNA'
+  skip_basecalling           = true
+  skip_demultiplexing        = true
+  skip_alignment             = true
+  skip_modification_analysis = true
 }

--- a/modules/local/process/check_samplesheet.nf
+++ b/modules/local/process/check_samplesheet.nf
@@ -47,5 +47,5 @@ def get_sample_info(LinkedHashMap sample, LinkedHashMap genomeMap) {
     input_file = sample.input_file ? file(sample.input_file, checkIfExists: true) : null
     gtf        = sample.gtf        ? file(sample.gtf, checkIfExists: true)        : gtf
 
-    return [ sample.sample, input_file, sample.barcode, fasta, gtf, sample.is_transcripts.toBoolean(), fasta.toString()+';'+gtf.toString() ]
+    return [ sample.sample, input_file, sample.barcode, fasta, gtf, sample.is_transcripts.toBoolean(), fasta.toString()+';'+gtf.toString(), sample.nanopolish_fast5 ]
 }

--- a/modules/local/process/m6anet_inference.nf
+++ b/modules/local/process/m6anet_inference.nf
@@ -1,0 +1,28 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+def options    = initOptions(params.options)
+
+process M6ANET_INFERENCE {
+    label 'process_medium'
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'rna_modification/m6anet_inference', publish_id:'') }
+
+ //   conda     (params.enable_conda ? "bioconda::nanopolish==0.13.2" : null) // need to get xpore onto conda
+    container "docker.io/yuukiiwa/m6anet:0.0.1"
+
+    input:
+    tuple path(dir), val(sample)
+    
+    output:
+    path "*", emit: m6anet_outputs
+
+    script:
+    def input_dir = dir+'/m6anet'
+    """
+    m6anet-run_inference --input_dir $input_dir --out_dir $sample  --batch_size 512 --num_workers $params.guppy_cpu_threads --num_iterations 5 --device cpu
+    """
+
+}

--- a/modules/local/process/m6anet_inference.nf
+++ b/modules/local/process/m6anet_inference.nf
@@ -5,6 +5,7 @@ params.options = [:]
 def options    = initOptions(params.options)
 
 process M6ANET_INFERENCE {
+    echo true
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
@@ -18,11 +19,13 @@ process M6ANET_INFERENCE {
     
     output:
     path "*", emit: m6anet_outputs
+    path "*_version.txt", emit: version
 
     script:
     def input_dir = dir+'/m6anet'
+    def out_dir = sample+"_results"
     """
-    m6anet-run_inference --input_dir $input_dir --out_dir $sample  --batch_size 512 --num_workers $params.guppy_cpu_threads --num_iterations 5 --device cpu
+    m6anet-run_inference --input_dir $input_dir --out_dir $out_dir  --batch_size 512 --num_workers $params.guppy_cpu_threads --num_iterations 5 --device cpu
+    echo '0.0.1' > m6anet_version.txt
     """
-
 }

--- a/modules/local/process/nanopolish.nf
+++ b/modules/local/process/nanopolish.nf
@@ -1,0 +1,31 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+def options    = initOptions(params.options)
+
+process NANOPOLISH {
+    label 'process_medium'
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+
+    conda     (params.enable_conda ? "bioconda::nanopolish==0.13.2" : null)
+    container "quay.io/biocontainers/nanopolish:0.13.2--he3b7ca5_2"
+
+    input:
+    tuple val(sample), path(genome), path(gtf), path(fast5), path(fastq), path(bam), path(bai)
+    
+    output:
+    tuple val(sample), path(genome), path(gtf), path("*eventalign.txt"), path("*summary.txt"), emit: nanopolish_outputs
+    path "*.version.txt"     ,emit: version
+
+    script:
+    sample_summary = "$sample" +"_summary.txt"
+    sample_eventalign = "$sample" +"_eventalign.txt" 
+    """
+    nanopolish index -d $fast5 $fastq
+    nanopolish eventalign  --reads $fastq --bam $bam --genome $genome --scale-events --signal-index --summary $sample_summary --threads $params.guppy_cpu_threads > $sample_eventalign
+    nanopolish --version | sed -e "s/nanopolish version //g" | head -n 1 > nanopolish.version.txt
+    """
+}

--- a/modules/local/process/xpore_diffmod.nf
+++ b/modules/local/process/xpore_diffmod.nf
@@ -1,0 +1,31 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+def options    = initOptions(params.options)
+
+process XPORE_DIFFMOD {
+    label 'process_medium'
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'rna_modification', publish_id:'') }
+
+ //   conda     (params.enable_conda ? "bioconda::nanopolish==0.13.2" : null) // need to get xpore onto conda
+    container "docker.io/yuukiiwa/xpore:w_m6anet"
+
+    input:
+    val dataprep_dirs
+    
+    output:
+    path "diffmod*", emit: diffmod_outputs
+    path "*_version.txt" , emit: version
+
+    script:
+    diffmod_config = "$workflow.workDir/*/*/diffmod_config.yml"
+    """
+    create_yml.py diffmod_config.yml $dataprep_dirs
+    xpore-diffmod --config $diffmod_config --n_processes $params.guppy_cpu_threads
+    python3 -c 'import xpore; print(xpore.__version__)' > xpore_version.txt
+    """
+
+}

--- a/modules/local/process/xpore_m6anet_dataprep.nf
+++ b/modules/local/process/xpore_m6anet_dataprep.nf
@@ -1,0 +1,54 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+def options    = initOptions(params.options)
+
+process XPORE_M6ANET_DATAPREP {
+    label 'process_medium'
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'rna_modification/dataprep', publish_id:'') }
+
+ //   conda     (params.enable_conda ? "bioconda::nanopolish==0.13.2" : null) // need to get xpore onto conda
+    container "docker.io/yuukiiwa/xpore:w_m6anet"
+
+    input:
+    tuple val(sample), path(genome), path(gtf), path(eventalign), path(nanopolish_summary)
+    
+    output:
+    tuple path("$sample"), val(sample), emit: dataprep_outputs
+
+    script:
+    if (params.skip_xpore){
+        def program = "m6anet"
+        """
+        xpore-dataprep \\
+        --eventalign $eventalign \\
+        --summary $nanopolish_summary \\
+        --out_dir $sample \\
+        --program $program \\
+        --genome --gtf_path_or_url $gtf --transcript_fasta_paths_or_urls $genome
+        """
+    } else if (params.skip_m6anet){
+        def program = "xpore"
+        """
+        xpore-dataprep \\
+        --eventalign $eventalign \\
+        --summary $nanopolish_summary \\
+        --out_dir $sample \\
+        --program $program \\
+        --genome --gtf_path_or_url $gtf --transcript_fasta_paths_or_urls $genome
+        """
+    } else {
+        def program = "xpore,m6anet"
+        """
+        xpore-dataprep \\
+        --eventalign $eventalign \\
+        --summary $nanopolish_summary \\
+        --out_dir $sample \\
+        --program $program \\
+        --genome --gtf_path_or_url $gtf --transcript_fasta_paths_or_urls $genome
+        """
+    }
+}

--- a/modules/local/process/xpore_m6anet_dataprep.nf
+++ b/modules/local/process/xpore_m6anet_dataprep.nf
@@ -27,8 +27,7 @@ process XPORE_M6ANET_DATAPREP {
         --eventalign $eventalign \\
         --summary $nanopolish_summary \\
         --out_dir $sample \\
-        --program $program \\
-        --genome --gtf_path_or_url $gtf --transcript_fasta_paths_or_urls $genome
+        --program $program
         """
     } else if (params.skip_m6anet){
         def program = "xpore"
@@ -47,8 +46,7 @@ process XPORE_M6ANET_DATAPREP {
         --eventalign $eventalign \\
         --summary $nanopolish_summary \\
         --out_dir $sample \\
-        --program $program \\
-        --genome --gtf_path_or_url $gtf --transcript_fasta_paths_or_urls $genome
+        --program $program
         """
     }
 }

--- a/modules/local/process/xpore_m6anet_dataprep.nf
+++ b/modules/local/process/xpore_m6anet_dataprep.nf
@@ -27,7 +27,8 @@ process XPORE_M6ANET_DATAPREP {
         --eventalign $eventalign \\
         --summary $nanopolish_summary \\
         --out_dir $sample \\
-        --program $program
+        --program $program \\
+        --genome --gtf_path_or_url $gtf --transcript_fasta_paths_or_urls $genome
         """
     } else if (params.skip_m6anet){
         def program = "xpore"
@@ -46,7 +47,8 @@ process XPORE_M6ANET_DATAPREP {
         --eventalign $eventalign \\
         --summary $nanopolish_summary \\
         --out_dir $sample \\
-        --program $program
+        --program $program \\
+        --genome --gtf_path_or_url $gtf --transcript_fasta_paths_or_urls $genome
         """
     }
 }

--- a/modules/local/subworkflow/rna_modifications_xpore_m6anet.nf
+++ b/modules/local/subworkflow/rna_modifications_xpore_m6anet.nf
@@ -1,0 +1,65 @@
+/*
+ * Transcript Discovery and Quantification with StringTie2 and FeatureCounts
+ */
+
+def nanopolish_options            = [:]
+def xpore_m6anet_dataprep_options = [:]
+def xpore_diffmod_options         = [:]
+def m6anet_inference_options      = [:]
+
+include { NANOPOLISH            } from '../process/nanopolish'            addParams( options: nanopolish_options            )
+include { XPORE_M6ANET_DATAPREP } from '../process/xpore_m6anet_dataprep' addParams( options: xpore_m6anet_dataprep_options )
+include { XPORE_DIFFMOD         } from '../process/xpore_diffmod'         addParams( options: xpore_diffmod_options         )
+include { M6ANET_INFERENCE      } from '../process/m6anet_inference'      addParams( options: m6anet_inference_options      )
+
+workflow RNA_MODIFICATION_XPORE_M6ANET {
+    take:
+    ch_sample
+    ch_nanopolish_sortbam
+
+    main:
+
+    ch_sample
+          .join(ch_nanopolish_sortbam)
+          .map { it -> [ it[0], it[2], it[3], it[7], it[6], it[8], it[9] ] }
+          .set { ch_nanopolish_input }
+
+    /*
+     * Align current signals to reference with Nanopolish
+     */
+    NANOPOLISH { ch_nanopolish_input }
+    ch_nanopolish_outputs = NANOPOLISH.out.nanopolish_outputs
+    nanopolish_version    = NANOPOLISH.out.version
+    
+    if (!params.skip_xpore || !params.skip_m6anet) {
+
+        /*
+         * Dataprep for xpore and/or m6anet
+         */
+        XPORE_M6ANET_DATAPREP( ch_nanopolish_outputs )
+        ch_dataprep_dirs = XPORE_M6ANET_DATAPREP.out.dataprep_outputs
+
+        if (!params.skip_xpore) {
+            ch_dataprep_dirs
+                .map{ it -> it[0]+','+it[1] }
+                .set{ ch_xpore_diffmod_inputs }
+            /*
+             * Differential modification expression with xpore
+             */
+            XPORE_DIFFMOD{ ch_xpore_diffmod_inputs.collect() }
+            xpore_version    = XPORE_DIFFMOD.out.version
+        }
+        if (!params.skip_m6anet) {
+            /*
+             * Detect m6A sites with m6anet
+             */
+            M6ANET_INFERENCE{ ch_dataprep_dirs }
+        }
+    }
+
+    emit:
+    ch_nanopolish_outputs
+    ch_dataprep_dirs
+    xpore_version
+    nanopolish_version
+}

--- a/modules/local/subworkflow/rna_modifications_xpore_m6anet.nf
+++ b/modules/local/subworkflow/rna_modifications_xpore_m6anet.nf
@@ -38,7 +38,7 @@ workflow RNA_MODIFICATION_XPORE_M6ANET {
          */
         XPORE_M6ANET_DATAPREP( ch_nanopolish_outputs )
         ch_dataprep_dirs = XPORE_M6ANET_DATAPREP.out.dataprep_outputs
-
+        xpore_version = ''
         if (!params.skip_xpore) {
             ch_dataprep_dirs
                 .map{ it -> it[0]+','+it[1] }
@@ -49,11 +49,13 @@ workflow RNA_MODIFICATION_XPORE_M6ANET {
             XPORE_DIFFMOD{ ch_xpore_diffmod_inputs.collect() }
             xpore_version    = XPORE_DIFFMOD.out.version
         }
+        m6anet_version = ''
         if (!params.skip_m6anet) {
             /*
              * Detect m6A sites with m6anet
              */
             M6ANET_INFERENCE{ ch_dataprep_dirs }
+            m6anet_version   = M6ANET_INFERENCE.out.version
         }
     }
 
@@ -62,4 +64,5 @@ workflow RNA_MODIFICATION_XPORE_M6ANET {
     ch_dataprep_dirs
     xpore_version
     nanopolish_version
+    m6anet_version
 }

--- a/nanoseq.nf
+++ b/nanoseq.nf
@@ -131,10 +131,10 @@ multiqc_options.args       += params.multiqc_title ? " --title \"$params.multiqc
 if (params.skip_alignment)  { multiqc_options['publish_dir'] = '' }
 
 // TO DO -- define options for the processes below
-def guppy_options    = modules['guppy']
-def qcat_options     = modules['qcat']
-def nanolyse_options = modules['nanolyse']
-def bambu_options    = modules['bambu']
+def guppy_options                 = modules['guppy']
+def qcat_options                  = modules['qcat']
+def nanolyse_options              = modules['nanolyse']
+def bambu_options                 = modules['bambu']
 
 include { GUPPY                 } from './modules/local/process/guppy'                 addParams( options: guppy_options                )
 include { QCAT                  } from './modules/local/process/qcat'                  addParams( options: qcat_options                 ) 
@@ -164,6 +164,10 @@ def stringtie2_options          = modules['stringtie2']
 def featurecounts_options       = modules['subread_featurecounts']
 def deseq2_options              = modules['deseq2']
 def dexseq_options              = modules['dexseq']
+def nanopolish_options          = modules['nanopolish']
+def xpore_m6anet_dataprep_options = modules['xpore_m6anet_dataprep']
+def xpore_diffmod_options = modules['xpore_diffmod']
+def m6anet_inference_options = modules['m6anet_inference']
 
 include { INPUT_CHECK                      } from './modules/local/subworkflow/input_check'                       addParams( options: [:] )
 include { QCBASECALL_PYCOQC_NANOPLOT       } from './modules/local/subworkflow/qcbasecall_pycoqc_nanoplot'        addParams( pycoqc_options: pycoqc_options, nanoplot_summary_options: nanoplot_summary_options )
@@ -175,6 +179,7 @@ include { BEDTOOLS_UCSC_BIGWIG             } from './modules/local/subworkflow/b
 include { BEDTOOLS_UCSC_BIGBED             } from './modules/local/subworkflow/bedtools_ucsc_bigbed'              addParams( bigbed_options: bigbed_options )
 include { QUANTIFY_STRINGTIE_FEATURECOUNTS } from './modules/local/subworkflow/quantify_stringtie_featurecounts'  addParams( stringtie2_options: stringtie2_options, featurecounts_options: featurecounts_options )
 include { DIFFERENTIAL_DESEQ2_DEXSEQ       } from './modules/local/subworkflow/differential_deseq2_dexseq'        addParams( deseq2_options: deseq2_options, dexseq_options: dexseq_options )
+include { RNA_MODIFICATION_XPORE_M6ANET    } from './modules/local/subworkflow/rna_modifications_xpore_m6anet'    addParams( nanopolish_options: nanopolish_options, xpore_m6anet_dataprep_options: xpore_m6anet_dataprep_options, xpore_diffmod_options: xpore_diffmod_options, m6anet_inference_options: m6anet_inference_options )
 
 ////////////////////////////////////////////////////
 /* --    IMPORT NF-CORE MODULES/SUBWORKFLOWS   -- */
@@ -349,10 +354,13 @@ workflow NANOSEQ{
        ch_view_sortbam
           .map { it -> [ it[0], it[3] ] }
           .set { ch_sortbam }
+       ch_view_sortbam
+          .map { it -> [ it[0], it[3], it[4] ] }
+          .set { ch_nanopolish_sortbam }
     } else {
        ch_sample
-           .map { it -> if (it[6].toString().endsWith('.bam')) [ it[0], it[6] ] }
-           .set { ch_sample_bam }
+          .map { it -> if (it[6].toString().endsWith('.bam')) [ it[0], it[6] ] }
+          .set { ch_sample_bam }
        BAM_RENAME ( ch_sample_bam )
        ch_sortbam = BAM_RENAME.out.sortbam_quant
     }
@@ -417,6 +425,10 @@ workflow NANOSEQ{
           ch_r_version = ch_r_version.mix(DIFFERENTIAL_DESEQ2_DEXSEQ.out.r_version.first().ifEmpty(null))
        }
        ch_software_versions = ch_software_versions.mix(ch_r_version.first().ifEmpty(null))
+    }
+
+    if (!params.skip_modification_analysis && params.protocol == 'directRNA') {
+        RNA_MODIFICATION_XPORE_M6ANET( ch_sample, ch_nanopolish_sortbam )
     }
 
     /*

--- a/nextflow.config
+++ b/nextflow.config
@@ -49,6 +49,11 @@ params {
   skip_quantification        = false
   skip_differential_analysis = false
 
+  // Options: Modification analysis
+  skip_modification_analysis = false
+  skip_xpore                 = false
+  skip_m6anet                = false
+
   // Options: QC
   skip_qc                    = false
   skip_pycoqc                = false


### PR DESCRIPTION
The non-DRACH motif bug was solved on my branch's `xpore-dataprep` for `m6anet`,  and I have updated `XPORE_M6ANET_DATAPREP` using the `--genome` option for running preprocess_gene_xpore_m6anet:
![Screenshot 2021-03-31 at 3 53 44 PM](https://user-images.githubusercontent.com/41866052/113110621-dd635d80-9239-11eb-8237-7b1639933bd9.png)

passing `--skip_m6anet` to the nanoseq:
![Screenshot 2021-03-31 at 4 34 24 PM](https://user-images.githubusercontent.com/41866052/113115637-35509300-923f-11eb-9fcb-26a541e5ea63.png)

passing `--skip_xpore` to nanoseq:
![Screenshot 2021-03-31 at 4 22 23 PM](https://user-images.githubusercontent.com/41866052/113115669-3f729180-923f-11eb-8b04-0fdfcf2129aa.png)

The linting test is not passing, which I have to fix them together with the [pull request](https://github.com/nf-core/nanoseq/pull/103) to `nf-core/nanoseq`